### PR TITLE
add flattened output for iterating in dependent modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,5 @@ No resources.
 | <a name="output_vnet_locations"></a> [vnet\_locations](#output\_vnet\_locations) | Map of vnet names where key in input key in network map and value is location of vnet that got created. |
 | <a name="output_vnet_address_spaces"></a> [vnet\_address\_spaces](#output\_vnet\_address\_spaces) | Map of vnet names where key in input key in network map and value is address of vnet that got created. |
 | <a name="output_vnet_subnet_name_id_map"></a> [vnet\_subnet\_name\_id\_map](#output\_vnet\_subnet\_name\_id\_map) | Outputs a subnet name to ID map for each Vnet |
+| <a name="output_vnet_subnet_name_id_map_flattened"></a> [vnet\_subnet\_name\_id\_map\_flattened](#output\_vnet\_subnet\_name\_id\_map\_flattened) | Flattened map of subnet names to ids for iterating in dependent modules. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,3 +45,17 @@ output "vnet_subnet_name_id_map" {
   description = "Outputs a subnet name to ID map for each Vnet"
   value       = { for k, v in var.network_map : k => module.network[k].subnet_name_id_map }
 }
+
+output "vnet_subnet_name_id_map_flattened" {
+  description = "Flattened map of subnet names to ids for iterating in dependent modules."
+  value = {
+    for item in flatten([
+      for k, v in var.network_map : [
+        for subnet_name, subnet_id in module.network[k].subnet_name_id_map : {
+          key   = subnet_name
+          value = subnet_id
+        }
+      ]
+    ]) : item.key => item.value
+  }
+}


### PR DESCRIPTION
a handful of dependent modules were running into problems with the new data structure of the outputs for this module. after working with @chris11-taylor-nttd on this, he helped by creating a local that would allow us to flatten the map that worked for a module.

this PR is to implement this logic in the collection instead as an output, which will allow dependent modules to just use this as a reference for their outputs instead of needing to define a new local with a flattened version of the map in each dependent module.